### PR TITLE
Disabling single use link until a fix is found

### DIFF
--- a/hyrax/app/views/hyrax/file_sets/show.html.erb
+++ b/hyrax/app/views/hyrax/file_sets/show.html.erb
@@ -1,0 +1,26 @@
+<% provide :page_title, @presenter.page_title %>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-xs-12 col-sm-4">
+      <%= render media_display_partial(@presenter), file_set: @presenter %>
+      <%= render 'show_actions', presenter: @presenter %>
+      <%# TODO: disabling single use links temporarily. See https://github.com/antleaf/wpi-repository-project/issues/32 %>
+      <%#= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
+    </div>
+    <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">
+      <header>
+        <%= render 'file_set_title', presenter: @presenter %>
+      </header>
+
+      <%# TODO: render 'show_descriptions' See https://github.com/samvera/hyrax/issues/1481 %>
+      <%= render 'show_details' %>
+      <%= render 'hyrax/users/activity_log', events: @presenter.events %>
+    </div><!-- /columns second -->
+  </div> <!-- /.row -->
+</div><!-- /.container-fluid -->
+
+<% @presenter.member_of_collection_ids.each do |collection_id| %>
+  <span class='hide analytics-event' data-category="file-set-in-collection" data-action="file-set-in-collection-view" data-name="<%= collection_id %>" >
+<% end %>
+<span class='hide analytics-event' data-category="file-set-in-work" data-action="file-set-in-work-view" data-name="<%= @presenter.parent.id %>" >
+<span class='hide analytics-event' data-category="file-set" data-action="file-set-view" data-name="<%= @presenter.id %>" >


### PR DESCRIPTION
This is a temporary fix for https://github.com/antleaf/wpi-repository-project/issues/32

I copied the template from Hyrax and disabled rendering single_use_links. see [line #7](https://github.com/samvera/hyrax/blob/v3.3.0/app/views/hyrax/file_sets/show.html.erb#L7) in Hyrax 3.3.0.